### PR TITLE
Allow events to work by using hostname instead of localhost for DeviceProxy

### DIFF
--- a/devicetest/context.py
+++ b/devicetest/context.py
@@ -1,6 +1,7 @@
 """Contain the context to run a device without a database."""
 
 # Imports
+import platform
 from socket import socket
 from functools import wraps
 from time import sleep, time
@@ -71,7 +72,7 @@ class TangoTestContext(object):
         self.port = port
         self.device_name = device_name
         self.server_name = "/".join(("dserver", server_name, instance_name))
-        self.host = "localhost:{0}/".format(self.port)
+        self.host="{0}:{1}/".format(platform.node(), self.port)
         self.device = self.server = None
         # File
         self.generate_db_file(server_name, instance_name, device_name,


### PR DESCRIPTION
It seems that events magically work if you use the hostname of the machine running the tests rather than localhost when setting up the DeviceProxy in context.py. I _think_ it should work on Windows, although I have only tested it on Linux.

If this looks good I could edit the Readme to indicate that this now works.
